### PR TITLE
[design/#15] - 메인 페이지(모바일) UI 퍼블리싱

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, viewport-fit=cover">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>hansung-agent-rag-fe</title>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, viewport-fit=cover">
     <title>hansung-agent-rag-fe</title>
   </head>
   <body>

--- a/src/constants/breakpoints.ts
+++ b/src/constants/breakpoints.ts
@@ -1,2 +1,2 @@
 /** theme.css의 --breakpoint-mobile과 동일한 값을 유지해야 합니다. */
-export const MOBILE_BREAKPOINT = 460;
+export const MOBILE_BREAKPOINT = 461;

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -1,58 +1,62 @@
-// 모바일에서 키보드가 올라올 때 변하는 실제 화면 높이와 키보드 활성화 상태를 감지하여 반환하는 훅
-import { useSyncExternalStore } from "react";
+import { useRef, useSyncExternalStore } from "react";
 
-const subscribe = (callback: () => void) => {
-  const vv = window.visualViewport;
-  if (!vv) return () => {};
-
-  const handleUpdate = () => {
-    // 인풋 포커스로 인해 브라우저가 레이아웃을 밀어올릴 때 즉시 0으로 고정
-    if (window.scrollY !== 0) {
-      window.scrollTo(0, 0);
-    }
-    callback();
-  };
-
-  vv.addEventListener("resize", handleUpdate);
-  vv.addEventListener("scroll", handleUpdate);
-
-  // 인풋 포커스 시 발생하는 강제 스크롤 방지
-  window.addEventListener("scroll", handleUpdate);
-
-  return () => {
-    vv.removeEventListener("resize", handleUpdate);
-    vv.removeEventListener("scroll", handleUpdate);
-    window.removeEventListener("scroll", handleUpdate);
-  };
-};
-
-const getSnapshot = () => {
-  const vv = window.visualViewport;
-  if (!vv) return "100dvh|false";
-
-  if (vv.offsetTop > 0) {
-    window.scrollTo(0, 0);
-  }
-
-  const height = `${vv.height}px`;
-  const isKeyboardOpen = vv.height < window.innerHeight * 0.8;
-
-  return `${height}|${isKeyboardOpen}`;
-};
-
-const getServerSnapshot = () => "100dvh|false";
+const getServerSnapshot = () => "0|false";
 
 export const useVisualViewport = (isMobile: boolean) => {
+  const initialHeightRef = useRef(
+    typeof window !== "undefined"
+      ? (window.visualViewport?.height ?? window.innerHeight)
+      : 0
+  );
+
+  const stableHeightRef = useRef(initialHeightRef.current);
+  const stableOffsetTopRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const listenerRef = useRef<(() => void) | null>(null);
+
+  const subscribe = useRef((callback: () => void) => {
+    const vv = window.visualViewport;
+    if (!vv) return () => {};
+
+    listenerRef.current = () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        const height = vv.height;
+        if (height && height >= 300) {
+          stableHeightRef.current = height;
+          stableOffsetTopRef.current = vv.offsetTop ?? 0;
+        }
+        callback();
+      }, 150);
+    };
+
+    vv.addEventListener("resize", listenerRef.current);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (listenerRef.current)
+        vv.removeEventListener("resize", listenerRef.current);
+    };
+  }).current;
+
+  const getSnapshot = () => {
+    const height = stableHeightRef.current;
+    const offsetTop = stableOffsetTopRef.current;
+    const isKeyboardOpen = height < initialHeightRef.current * 0.75;
+    return `${height}|${isKeyboardOpen}|${offsetTop}`;
+  };
+
   const snapshot = useSyncExternalStore(
     isMobile ? subscribe : () => () => {},
     isMobile ? getSnapshot : getServerSnapshot,
     getServerSnapshot
   );
 
-  const [viewportHeight, isKeyboardOpenStr] = snapshot.split("|");
+  const [viewportHeight, isKeyboardOpenStr, offsetTop] = snapshot.split("|");
 
   return {
-    viewportHeight,
+    viewportHeight: viewportHeight ? `${viewportHeight}px` : "100dvh",
     isKeyboardOpen: isKeyboardOpenStr === "true",
+    offsetTop: offsetTop ? `${offsetTop}px` : "0px",
   };
 };

--- a/src/hooks/useVisualViewport.ts
+++ b/src/hooks/useVisualViewport.ts
@@ -1,0 +1,58 @@
+// 모바일에서 키보드가 올라올 때 변하는 실제 화면 높이와 키보드 활성화 상태를 감지하여 반환하는 훅
+import { useSyncExternalStore } from "react";
+
+const subscribe = (callback: () => void) => {
+  const vv = window.visualViewport;
+  if (!vv) return () => {};
+
+  const handleUpdate = () => {
+    // 인풋 포커스로 인해 브라우저가 레이아웃을 밀어올릴 때 즉시 0으로 고정
+    if (window.scrollY !== 0) {
+      window.scrollTo(0, 0);
+    }
+    callback();
+  };
+
+  vv.addEventListener("resize", handleUpdate);
+  vv.addEventListener("scroll", handleUpdate);
+
+  // 인풋 포커스 시 발생하는 강제 스크롤 방지
+  window.addEventListener("scroll", handleUpdate);
+
+  return () => {
+    vv.removeEventListener("resize", handleUpdate);
+    vv.removeEventListener("scroll", handleUpdate);
+    window.removeEventListener("scroll", handleUpdate);
+  };
+};
+
+const getSnapshot = () => {
+  const vv = window.visualViewport;
+  if (!vv) return "100dvh|false";
+
+  if (vv.offsetTop > 0) {
+    window.scrollTo(0, 0);
+  }
+
+  const height = `${vv.height}px`;
+  const isKeyboardOpen = vv.height < window.innerHeight * 0.8;
+
+  return `${height}|${isKeyboardOpen}`;
+};
+
+const getServerSnapshot = () => "100dvh|false";
+
+export const useVisualViewport = (isMobile: boolean) => {
+  const snapshot = useSyncExternalStore(
+    isMobile ? subscribe : () => () => {},
+    isMobile ? getSnapshot : getServerSnapshot,
+    getServerSnapshot
+  );
+
+  const [viewportHeight, isKeyboardOpenStr] = snapshot.split("|");
+
+  return {
+    viewportHeight,
+    isKeyboardOpen: isKeyboardOpenStr === "true",
+  };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
 }
 @import './styles/animation.css';
 
-html, body {
+/* html, body {
   overflow: hidden; 
   overscroll-behavior-y: none; 
-}
+} */

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,9 @@
 }
 @import './styles/animation.css';
 
-/* html, body {
-  overflow: hidden; 
-  overscroll-behavior-y: none; 
-} */
+html, body {
+  overflow: hidden;
+  height: 100%;
+  position: fixed;
+  width: 100%;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,8 @@
   --font-sans: 'Pretendard', sans-serif;
 }
 @import './styles/animation.css';
+
+html, body {
+  overflow: hidden; 
+  overscroll-behavior-y: none; 
+}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -9,7 +9,7 @@ const RootLayout = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(false);
 
   return (
-    <div className="relative flex w-full h-screen">
+    <div className="relative flex w-full h-dvh overflow-hidden">
       {/* 배경 이미지 */}
       <div
         className="absolute inset-0 -z-10 w-full h-full"
@@ -38,7 +38,7 @@ const RootLayout = () => {
           />
         )}
         <div
-          className="fixed left-0 top-0 h-screen"
+          className="fixed left-0 top-0 h-dvh"
           style={{
             zIndex: isSidebarOpen
               ? Z_INDEX.SIDEBAR_OPEN
@@ -53,7 +53,7 @@ const RootLayout = () => {
         </div>
       </div>
 
-      <div className="flex flex-col flex-1 min-w-0 max-tablet:ml-17.5 max-mobile:ml-0">
+      <div className="flex flex-col flex-1 min-w-0 max-tablet:ml-17.5 max-mobile:ml-0 overflow-hidden">
         {/* 상: 헤더 */}
         <Header />
 

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -9,7 +9,7 @@ const RootLayout = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(false);
 
   return (
-    <div className="relative flex w-full h-screen overflow-hidden">
+    <div className="relative flex w-full h-screen">
       {/* 배경 이미지 */}
       <div
         className="absolute inset-0 -z-10 w-full h-full"
@@ -39,7 +39,11 @@ const RootLayout = () => {
         )}
         <div
           className="fixed left-0 top-0 h-screen"
-          style={{ zIndex: isSidebarOpen ? Z_INDEX.SIDEBAR_OPEN : Z_INDEX.SIDEBAR_CLOSED }}
+          style={{
+            zIndex: isSidebarOpen
+              ? Z_INDEX.SIDEBAR_OPEN
+              : Z_INDEX.SIDEBAR_CLOSED,
+          }}
         >
           <Sidebar
             isMobileOverlay={true}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -58,7 +58,7 @@ const RootLayout = () => {
         <Header />
 
         {/* 메인 콘텐츠 */}
-        <main className="flex-1 overflow-auto bg-transparent">
+        <main className="flex-1 overflow-hidden bg-transparent min-h-0">
           <Outlet />
         </main>
       </div>

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { ChatInput } from "@/components/input/ChatInput";
 import ActionButton from "./components/ActionButton";
 import HomePageButton from "./components/HomePageButton";
@@ -7,44 +8,87 @@ import { useIsMobile } from "@/hooks/useIsMobile";
 
 const MainPage = () => {
   const isMobile = useIsMobile();
+  const [viewportHeight, setViewportHeight] = useState("100dvh");
+  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isMobile || !window.visualViewport) return;
+
+    const handleResize = () => {
+      const vv = window.visualViewport!;
+      setViewportHeight(`${vv.height}px`);
+      setIsKeyboardOpen(vv.height < window.innerHeight * 0.8);
+      window.scrollTo(0, 0);
+    };
+
+    window.visualViewport.addEventListener("resize", handleResize);
+    window.visualViewport.addEventListener("scroll", handleResize);
+    return () => {
+      window.visualViewport?.removeEventListener("resize", handleResize);
+      window.visualViewport?.removeEventListener("scroll", handleResize);
+    };
+  }, [isMobile]);
+
+  const containerStyle = isMobile
+    ? "absolute inset-0 flex flex-col items-center overflow-hidden pt-28"
+    : "flex flex-col items-center gap-6 pt-[10dvh]";
 
   return (
-    <div className="flex flex-col items-center gap-6 p-6.25 max-mobile:px-0 text-center">
-      <section className="flex flex-col gap-2 items-center">
-        <p className="text-h4-b max-laptop:text-h5-b max-mobile:text-h5-m text-header-blue">
-          HANSUNG AI ASSISTANT
-        </p>
-        <p className="text-h1-b max-laptop:text-h2-b max-mobile:text-h4-b text-body">
-          한성대 AI 워크스페이스
-        </p>
-      </section>
-      <p className="text-r-28 max-laptop:text-r-22 max-mobile:text-h5-r text-body mt-7.75 max-laptop:mt-5 max-mobile:mt-2.75 mb-5.75 max-laptop:mb-4 max-mobile:mb-0 animate-dissolve">
-        안녕하세요, 무엇을 도와드릴까요?
-      </p>
+    <div
+      className={`w-full text-center transition-all duration-300 ${containerStyle}`}
+      style={isMobile ? { height: viewportHeight } : {}}
+    >
+      <div
+        className={`w-full flex flex-col items-center shrink-0 transition-all ${
+          isMobile && isKeyboardOpen ? "pt-4" : "pt-0"
+        }`}
+      >
+        <section className="flex flex-col gap-2 items-center">
+          <p className="text-h4-b max-laptop:text-h5-b max-mobile:text-h5-m text-header-blue">
+            HANSUNG AI ASSISTANT
+          </p>
+          <p className="text-h1-b max-laptop:text-h2-b max-mobile:text-h4-b text-body">
+            한성대 AI 워크스페이스
+          </p>
+        </section>
 
-      {/* 추천 문장 */}
-      <SuggestChipGroup />
-
-      <div className="w-full main-chat-pl main-chat-pr">
-        <ChatInput />
+        <p className="text-r-28 max-laptop:text-r-22 max-mobile:text-h5-r text-body mt-7.75 max-laptop:mt-6 max-mobile:mt-5.25 mb-5.75 max-laptop:mb-4 max-mobile:mb-2 animate-dissolve">
+          안녕하세요, 무엇을 도와드릴까요?
+        </p>
       </div>
 
-      {!isMobile && (
-        <>
-          <section className="flex gap-4 max-laptop:gap-3.25 pt-4 max-laptop:pt-2">
-            {ACTION_BUTTONS.map(({ variant, label }) => (
-              <ActionButton
-                key={variant}
-                variant={variant}
-                label={label}
-                onClick={() => {}}
-              />
-            ))}
-          </section>
+      {/* 추천 문장 */}
+      <div
+        className={`w-full flex flex-col items-center ${isMobile ? "flex-1 overflow-y-auto no-scrollbar py-2" : ""}`}
+      >
+        <SuggestChipGroup />
+      </div>
 
-          <HomePageButton />
-        </>
-      )}
+      <div
+        className={`w-full main-chat-pl main-chat-pr max-mobile:px-4 shrink-0 ${
+          isMobile ? "mt-auto pb-6" : "pb-10"
+        }`}
+      >
+        <div className="w-full">
+          <ChatInput />
+        </div>
+
+        {!isMobile && (
+          <>
+            <section className="flex justify-center gap-4 max-laptop:gap-3.25 pt-4 max-laptop:pt-2">
+              {ACTION_BUTTONS.map(({ variant, label }) => (
+                <ActionButton
+                  key={variant}
+                  variant={variant}
+                  label={label}
+                  onClick={() => {}}
+                />
+              ))}
+            </section>
+            <HomePageButton />
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -1,33 +1,15 @@
-import { useState, useEffect } from "react";
 import { ChatInput } from "@/components/input/ChatInput";
 import ActionButton from "./components/ActionButton";
 import HomePageButton from "./components/HomePageButton";
 import SuggestChipGroup from "./components/SuggestChipGroup";
 import { ACTION_BUTTONS } from "@/constants/actionButtons";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useVisualViewport } from "@/hooks/useVisualViewport";
 
 const MainPage = () => {
   const isMobile = useIsMobile();
-  const [viewportHeight, setViewportHeight] = useState("100dvh");
-  const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
 
-  useEffect(() => {
-    if (!isMobile || !window.visualViewport) return;
-
-    const handleResize = () => {
-      const vv = window.visualViewport!;
-      setViewportHeight(`${vv.height}px`);
-      setIsKeyboardOpen(vv.height < window.innerHeight * 0.8);
-      window.scrollTo(0, 0);
-    };
-
-    window.visualViewport.addEventListener("resize", handleResize);
-    window.visualViewport.addEventListener("scroll", handleResize);
-    return () => {
-      window.visualViewport?.removeEventListener("resize", handleResize);
-      window.visualViewport?.removeEventListener("scroll", handleResize);
-    };
-  }, [isMobile]);
+  const { viewportHeight, isKeyboardOpen } = useVisualViewport(isMobile);
 
   const containerStyle = isMobile
     ? "absolute inset-0 flex flex-col items-center overflow-hidden pt-28"
@@ -59,7 +41,9 @@ const MainPage = () => {
 
       {/* 추천 문장 */}
       <div
-        className={`w-full flex flex-col items-center ${isMobile ? "flex-1 overflow-y-auto no-scrollbar py-2" : ""}`}
+        className={`w-full flex flex-col items-center ${
+          isMobile ? "flex-1 overflow-y-auto no-scrollbar py-2" : ""
+        }`}
       >
         <SuggestChipGroup />
       </div>
@@ -75,7 +59,7 @@ const MainPage = () => {
 
         {!isMobile && (
           <>
-            <section className="flex justify-center gap-4 max-laptop:gap-3.25 pt-4 max-laptop:pt-2">
+            <section className="flex justify-center gap-4 max-laptop:gap-3.25 pt-10 max-laptop:pt-8">
               {ACTION_BUTTONS.map(({ variant, label }) => (
                 <ActionButton
                   key={variant}

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -8,23 +8,27 @@ import { useVisualViewport } from "@/hooks/useVisualViewport";
 
 const MainPage = () => {
   const isMobile = useIsMobile();
-
-  const { viewportHeight, isKeyboardOpen } = useVisualViewport(isMobile);
-
-  const containerStyle = isMobile
-    ? "absolute inset-0 flex flex-col items-center overflow-hidden pt-28"
-    : "flex flex-col items-center gap-6 pt-[10dvh]";
+  const { viewportHeight, offsetTop } = useVisualViewport(isMobile);
 
   return (
     <div
-      className={`w-full text-center transition-all duration-300 ${containerStyle}`}
-      style={isMobile ? { height: viewportHeight } : {}}
+      className={`w-full text-center flex flex-col items-center overflow-hidden ${
+        isMobile ? "pt-28" : "gap-6 pt-[10dvh]"
+      }`}
+      style={
+        isMobile
+          ? {
+              height: viewportHeight,
+              top: offsetTop,
+              position: "fixed",
+              left: 0,
+              right: 0,
+            }
+          : { height: "100%" }
+      }
     >
-      <div
-        className={`w-full flex flex-col items-center shrink-0 transition-all ${
-          isMobile && isKeyboardOpen ? "pt-4" : "pt-0"
-        }`}
-      >
+      {/* 상단 고정 텍스트 */}
+      <div className="w-full flex flex-col items-center shrink-0">
         <section className="flex flex-col gap-2 items-center">
           <p className="text-h4-b max-laptop:text-h5-b max-mobile:text-h5-m text-header-blue">
             HANSUNG AI ASSISTANT
@@ -33,7 +37,6 @@ const MainPage = () => {
             한성대 AI 워크스페이스
           </p>
         </section>
-
         <p className="text-r-28 max-laptop:text-r-22 max-mobile:text-h5-r text-body mt-7.75 max-laptop:mt-6 max-mobile:mt-5.25 mb-5.75 max-laptop:mb-4 max-mobile:mb-2 animate-dissolve">
           안녕하세요, 무엇을 도와드릴까요?
         </p>
@@ -42,21 +45,18 @@ const MainPage = () => {
       {/* 추천 문장 */}
       <div
         className={`w-full flex flex-col items-center ${
-          isMobile ? "flex-1 overflow-y-auto no-scrollbar py-2" : ""
+          isMobile ? "flex-1 min-h-0 overflow-y-auto no-scrollbar py-2" : ""
         }`}
       >
         <SuggestChipGroup />
       </div>
 
       <div
-        className={`w-full main-chat-pl main-chat-pr max-mobile:px-4 shrink-0 ${
-          isMobile ? "mt-auto pb-6" : "pb-10"
+        className={`w-full main-chat-pl main-chat-pr shrink-0 max-mobile:px-4 ${
+          isMobile ? "pb-4" : "pb-10"
         }`}
       >
-        <div className="w-full">
-          <ChatInput />
-        </div>
-
+        <ChatInput />
         {!isMobile && (
           <>
             <section className="flex justify-center gap-4 max-laptop:gap-3.25 pt-10 max-laptop:pt-8">

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -1,53 +1,50 @@
 import { ChatInput } from "@/components/input/ChatInput";
-import SuggestChip from "./components/SuggestChip";
 import ActionButton from "./components/ActionButton";
 import HomePageButton from "./components/HomePageButton";
+import SuggestChipGroup from "./components/SuggestChipGroup";
 import { ACTION_BUTTONS } from "@/constants/actionButtons";
-
-// 임시 추천 질문 데이터
-const SUGGEST_CHIPS = [
-  { variant: 1, label: "올해 미디어 디자인 트랙 졸업 요건이 뭐야?" },
-  { variant: 2, label: "세미나실 이용하려면 어떻게 해?" },
-  { variant: 3, label: "학점은행제가 뭐야?" },
-] as const;
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 const MainPage = () => {
+  const isMobile = useIsMobile();
+
   return (
-    <div className="flex flex-col items-center gap-6 p-6.25 text-center">
+    <div className="flex flex-col items-center gap-6 p-6.25 max-mobile:px-0 text-center">
       <section className="flex flex-col gap-2 items-center">
-        <p className="text-h4-b max-laptop:text-h5-b text-header-blue">
+        <p className="text-h4-b max-laptop:text-h5-b max-mobile:text-h5-m text-header-blue">
           HANSUNG AI ASSISTANT
         </p>
-        <p className="text-h1-b max-laptop:text-h2-b text-body">
+        <p className="text-h1-b max-laptop:text-h2-b max-mobile:text-h4-b text-body">
           한성대 AI 워크스페이스
         </p>
       </section>
-      <p className="text-r-28 max-laptop:text-r-22 text-body mt-7.75 max-laptop:mt-5 mb-5.75 max-laptop:mb-4 animate-dissolve">
+      <p className="text-r-28 max-laptop:text-r-22 max-mobile:text-h5-r text-body mt-7.75 max-laptop:mt-5 max-mobile:mt-2.75 mb-5.75 max-laptop:mb-4 max-mobile:mb-0 animate-dissolve">
         안녕하세요, 무엇을 도와드릴까요?
       </p>
 
-      <section className="flex gap-6 max-laptop:gap-4 max-tablet:gap-3">
-        {SUGGEST_CHIPS.map(({ variant, label }) => (
-          <SuggestChip key={variant} variant={variant} label={label} />
-        ))}
-      </section>
+      {/* 추천 문장 */}
+      <SuggestChipGroup />
 
       <div className="w-full main-chat-pl main-chat-pr">
         <ChatInput />
       </div>
 
-      <section className="flex gap-4 max-laptop:gap-3.25 pt-4 max-laptop:pt-2">
-        {ACTION_BUTTONS.map(({ variant, label }) => (
-          <ActionButton
-            key={variant}
-            variant={variant}
-            label={label}
-            onClick={() => {}}
-          />
-        ))}
-      </section>
+      {!isMobile && (
+        <>
+          <section className="flex gap-4 max-laptop:gap-3.25 pt-4 max-laptop:pt-2">
+            {ACTION_BUTTONS.map(({ variant, label }) => (
+              <ActionButton
+                key={variant}
+                variant={variant}
+                label={label}
+                onClick={() => {}}
+              />
+            ))}
+          </section>
 
-      <HomePageButton />
+          <HomePageButton />
+        </>
+      )}
     </div>
   );
 };

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -12,7 +12,7 @@ const MainPage = () => {
 
   return (
     <div
-      className={`w-full text-center flex flex-col items-center overflow-hidden ${
+      className={`w-full text-center flex flex-col items-center overflow-hidden scrollbar-hide ${
         isMobile ? "pt-28" : "gap-6 pt-[10dvh]"
       }`}
       style={

--- a/src/pages/mainPage/MainPage.tsx
+++ b/src/pages/mainPage/MainPage.tsx
@@ -26,7 +26,7 @@ const MainPage = () => {
         안녕하세요, 무엇을 도와드릴까요?
       </p>
 
-      <section className="flex gap-6">
+      <section className="flex gap-6 max-laptop:gap-4 max-tablet:gap-3">
         {SUGGEST_CHIPS.map(({ variant, label }) => (
           <SuggestChip key={variant} variant={variant} label={label} />
         ))}

--- a/src/pages/mainPage/components/SuggestChip.tsx
+++ b/src/pages/mainPage/components/SuggestChip.tsx
@@ -17,8 +17,8 @@ const SuggestChip = ({ variant, label, onClick }: SuggestChipProps) => {
     <button
       type="button"
       onClick={onClick}
-      className={`inline-flex items-center px-6.25 py-[0.83rem] max-laptop:px-5 max-laptop:py-2.75 rounded-3xl shadow-suggest
-        border text-h5-r max-laptop:text-h6-r whitespace-nowrap bg-bg-white
+      className={`inline-flex items-center px-6.25 py-[0.83rem] max-laptop:px-5 max-laptop:py-2.75 max-tablet:px-4 max-tablet:py-2 rounded-3xl shadow-suggest
+        border text-h5-r max-laptop:text-h6-r max-tablet:text-r-12  whitespace-nowrap bg-bg-white
         transition-opacity duration-150
         hover:opacity-70 active:scale-95 cursor-pointer ${variantStyles[variant]}
       `}

--- a/src/pages/mainPage/components/SuggestChip.tsx
+++ b/src/pages/mainPage/components/SuggestChip.tsx
@@ -1,4 +1,4 @@
-type SuggestChipVariant = 1 | 2 | 3;
+type SuggestChipVariant = 1 | 2 | 3 | 4 | 5 | 6;
 
 interface SuggestChipProps {
   label: string;
@@ -10,6 +10,9 @@ const variantStyles: Record<SuggestChipVariant, string> = {
   1: "border-suggest-1 text-suggest-1",
   2: "border-suggest-2 text-suggest-2",
   3: "border-suggest-3 text-suggest-3",
+  4: "border-suggest-2 text-suggest-2",
+  5: "border-suggest-3 text-suggest-3",
+  6: "border-suggest-1 text-suggest-1",
 };
 
 const SuggestChip = ({ variant, label, onClick }: SuggestChipProps) => {
@@ -17,7 +20,7 @@ const SuggestChip = ({ variant, label, onClick }: SuggestChipProps) => {
     <button
       type="button"
       onClick={onClick}
-      className={`inline-flex items-center px-6.25 py-[0.83rem] max-laptop:px-5 max-laptop:py-2.75 max-tablet:px-4 max-tablet:py-2 rounded-3xl shadow-suggest
+      className={`inline-flex items-center px-6.25 py-[0.83rem] max-laptop:px-5 max-laptop:py-2.75 max-tablet:px-4 rounded-3xl shadow-suggest
         border text-h5-r max-laptop:text-h6-r max-tablet:text-r-12  whitespace-nowrap bg-bg-white
         transition-opacity duration-150
         hover:opacity-70 active:scale-95 cursor-pointer ${variantStyles[variant]}

--- a/src/pages/mainPage/components/SuggestChipGroup.tsx
+++ b/src/pages/mainPage/components/SuggestChipGroup.tsx
@@ -2,7 +2,6 @@ import SuggestChip from "./SuggestChip";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useVisualViewport } from "@/hooks/useVisualViewport";
 
-// 임시 추천 문장 데이터
 const SUGGEST_CHIPS = [
   { variant: 1, label: "올해 미디어 디자인 트랙 졸업 요건이 뭐야?" },
   { variant: 2, label: "세미나실 이용하려면 어떻게 해?" },
@@ -20,41 +19,49 @@ const SuggestChipGroup = () => {
   const bottomChips = SUGGEST_CHIPS.slice(3, 6);
 
   if (isMobile) {
-    // 키보드가 올라왔을 때: 6개 1줄
-    if (isKeyboardOpen) {
-      return (
-        <div className="w-full overflow-x-auto no-scrollbar flex gap-3 px-4 py-2">
-          {SUGGEST_CHIPS.map(({ variant, label }) => (
-            <div key={`kb-${variant}`} className="whitespace-nowrap shrink-0">
-              <SuggestChip variant={variant} label={label} />
-            </div>
-          ))}
-        </div>
-      );
-    }
-
-    // 모바일: 3개씩 2줄 마키 애니메이션
     return (
-      <div className="w-full overflow-hidden flex flex-col gap-4 py-4">
-        <div className="flex w-max animate-marquee gap-4 pr-4">
-          {[...topChips, ...topChips].map(({ variant, label }, index) => (
-            <SuggestChip
-              key={`top-${variant}-${index < topChips.length ? "orig" : "clone"}`}
-              variant={variant}
-              label={label}
-            />
-          ))}
-        </div>
-
-        <div className="flex w-max animate-marquee gap-4 pr-4">
-          {[...bottomChips, ...bottomChips].map(({ variant, label }, index) => (
-            <SuggestChip
-              key={`bot-${variant}-${index < bottomChips.length ? "orig" : "clone"}`}
-              variant={variant}
-              label={label}
-            />
-          ))}
-        </div>
+      <div className="w-full overflow-hidden flex flex-col gap-4 py-4 transition-all duration-500">
+        {isKeyboardOpen ? (
+          /* 키보드 활성 시: 6개 1줄 마키 애니메이션 */
+          <div className="flex w-max animate-marquee gap-4 px-4">
+            {[...SUGGEST_CHIPS, ...SUGGEST_CHIPS].map(
+              ({ variant, label }, index) => (
+                <div
+                  key={`kb-${variant}-${index < SUGGEST_CHIPS.length ? "orig" : "clone"}`}
+                  className="shrink-0"
+                >
+                  <SuggestChip variant={variant} label={label} />
+                </div>
+              )
+            )}
+          </div>
+        ) : (
+          /* 평상시: 3개씩 2줄 마키 애니메이션 */
+          <>
+            <div className="flex w-max animate-marquee gap-4 px-4">
+              {[...topChips, ...topChips].map(({ variant, label }, index) => (
+                <div
+                  key={`top-${variant}-${index < topChips.length ? "orig" : "clone"}`}
+                  className="shrink-0"
+                >
+                  <SuggestChip variant={variant} label={label} />
+                </div>
+              ))}
+            </div>
+            <div className="flex w-max animate-marquee gap-4 px-4">
+              {[...bottomChips, ...bottomChips].map(
+                ({ variant, label }, index) => (
+                  <div
+                    key={`bot-${variant}-${index < bottomChips.length ? "orig" : "clone"}`}
+                    className="shrink-0"
+                  >
+                    <SuggestChip variant={variant} label={label} />
+                  </div>
+                )
+              )}
+            </div>
+          </>
+        )}
       </div>
     );
   }

--- a/src/pages/mainPage/components/SuggestChipGroup.tsx
+++ b/src/pages/mainPage/components/SuggestChipGroup.tsx
@@ -1,0 +1,68 @@
+import SuggestChip from "./SuggestChip";
+import { useIsMobile } from "@/hooks/useIsMobile";
+
+// 임시 추천 문장 데이터
+const SUGGEST_CHIPS = [
+  { variant: 1, label: "올해 미디어 디자인 트랙 졸업 요건이 뭐야?" },
+  { variant: 2, label: "세미나실 이용하려면 어떻게 해?" },
+  { variant: 3, label: "학점은행제가 뭐야?" },
+  { variant: 4, label: "도서관 운영 시간 언제까지야?" },
+  { variant: 5, label: "이번주 학생식당 메뉴 알려줘" },
+  { variant: 6, label: "셔틀버스 시간표 보여줘" },
+] as const;
+
+const SuggestChipGroup = () => {
+  const isMobile = useIsMobile();
+
+  const topChips = SUGGEST_CHIPS.slice(0, 3);
+  const bottomChips = SUGGEST_CHIPS.slice(3, 6);
+
+  if (isMobile) {
+    return (
+      <div className="w-full overflow-hidden flex flex-col gap-4 py-4">
+        <div className="flex w-max animate-marquee gap-4 pr-4 hover:[animation-play-state:paused]">
+          {topChips.map(({ variant, label }) => (
+            <SuggestChip
+              key={`top-first-${variant}`}
+              variant={variant}
+              label={label}
+            />
+          ))}
+          {topChips.map(({ variant, label }) => (
+            <SuggestChip
+              key={`top-second-${variant}`}
+              variant={variant}
+              label={label}
+            />
+          ))}
+        </div>
+        <div className="flex w-max animate-marquee gap-4 pr-4 hover:[animation-play-state:paused]">
+          {bottomChips.map(({ variant, label }) => (
+            <SuggestChip
+              key={`bottom-first-${variant}`}
+              variant={variant}
+              label={label}
+            />
+          ))}
+          {bottomChips.map(({ variant, label }) => (
+            <SuggestChip
+              key={`bottom-second-${variant}`}
+              variant={variant}
+              label={label}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <section className="flex gap-6 max-laptop:gap-4 max-tablet:gap-3">
+      {topChips.map(({ variant, label }) => (
+        <SuggestChip key={variant} variant={variant} label={label} />
+      ))}
+    </section>
+  );
+};
+
+export default SuggestChipGroup;

--- a/src/pages/mainPage/components/SuggestChipGroup.tsx
+++ b/src/pages/mainPage/components/SuggestChipGroup.tsx
@@ -37,32 +37,19 @@ const SuggestChipGroup = () => {
     return (
       <div className="w-full overflow-hidden flex flex-col gap-4 py-4">
         <div className="flex w-max animate-marquee gap-4 pr-4">
-          {topChips.map(({ variant, label }) => (
+          {[...topChips, ...topChips].map(({ variant, label }, index) => (
             <SuggestChip
-              key={`top-f-${variant}`}
-              variant={variant}
-              label={label}
-            />
-          ))}
-          {topChips.map(({ variant, label }) => (
-            <SuggestChip
-              key={`top-s-${variant}`}
+              key={`top-${variant}-${index < topChips.length ? "orig" : "clone"}`}
               variant={variant}
               label={label}
             />
           ))}
         </div>
+
         <div className="flex w-max animate-marquee gap-4 pr-4">
-          {bottomChips.map(({ variant, label }) => (
+          {[...bottomChips, ...bottomChips].map(({ variant, label }, index) => (
             <SuggestChip
-              key={`bot-f-${variant}`}
-              variant={variant}
-              label={label}
-            />
-          ))}
-          {bottomChips.map(({ variant, label }) => (
-            <SuggestChip
-              key={`bot-s-${variant}`}
+              key={`bot-${variant}-${index < bottomChips.length ? "orig" : "clone"}`}
               variant={variant}
               label={label}
             />

--- a/src/pages/mainPage/components/SuggestChipGroup.tsx
+++ b/src/pages/mainPage/components/SuggestChipGroup.tsx
@@ -1,5 +1,6 @@
 import SuggestChip from "./SuggestChip";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { useVisualViewport } from "@/hooks/useVisualViewport";
 
 // 임시 추천 문장 데이터
 const SUGGEST_CHIPS = [
@@ -13,40 +14,55 @@ const SUGGEST_CHIPS = [
 
 const SuggestChipGroup = () => {
   const isMobile = useIsMobile();
+  const { isKeyboardOpen } = useVisualViewport(isMobile);
 
   const topChips = SUGGEST_CHIPS.slice(0, 3);
   const bottomChips = SUGGEST_CHIPS.slice(3, 6);
 
   if (isMobile) {
+    // 키보드가 올라왔을 때: 6개 1줄
+    if (isKeyboardOpen) {
+      return (
+        <div className="w-full overflow-x-auto no-scrollbar flex gap-3 px-4 py-2">
+          {SUGGEST_CHIPS.map(({ variant, label }) => (
+            <div key={`kb-${variant}`} className="whitespace-nowrap shrink-0">
+              <SuggestChip variant={variant} label={label} />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    // 모바일: 3개씩 2줄 마키 애니메이션
     return (
       <div className="w-full overflow-hidden flex flex-col gap-4 py-4">
-        <div className="flex w-max animate-marquee gap-4 pr-4 hover:[animation-play-state:paused]">
+        <div className="flex w-max animate-marquee gap-4 pr-4">
           {topChips.map(({ variant, label }) => (
             <SuggestChip
-              key={`top-first-${variant}`}
+              key={`top-f-${variant}`}
               variant={variant}
               label={label}
             />
           ))}
           {topChips.map(({ variant, label }) => (
             <SuggestChip
-              key={`top-second-${variant}`}
+              key={`top-s-${variant}`}
               variant={variant}
               label={label}
             />
           ))}
         </div>
-        <div className="flex w-max animate-marquee gap-4 pr-4 hover:[animation-play-state:paused]">
+        <div className="flex w-max animate-marquee gap-4 pr-4">
           {bottomChips.map(({ variant, label }) => (
             <SuggestChip
-              key={`bottom-first-${variant}`}
+              key={`bot-f-${variant}`}
               variant={variant}
               label={label}
             />
           ))}
           {bottomChips.map(({ variant, label }) => (
             <SuggestChip
-              key={`bottom-second-${variant}`}
+              key={`bot-s-${variant}`}
               variant={variant}
               label={label}
             />

--- a/src/styles/animation.css
+++ b/src/styles/animation.css
@@ -3,7 +3,20 @@
     to   { opacity: 1; }
 }
 
+@keyframes marquee {
+  0% { transform: translateX(0%); }
+  100% { transform: translateX(-50%); }
+}
+
+@keyframes marquee-reverse {
+  0% { transform: translateX(-50%); }
+  100% { transform: translateX(0%); }
+}
+
 @theme {
     /* Dissolve: 800ms 딜레이 후 서서히 나타남 */
     --animate-dissolve: dissolve 900ms cubic-bezier(0.4, 0, 0.2, 1) 800ms both;
+
+    /* Marquee: 20초 동안 일정한 속도로 왼쪽으로 무한 스크롤 */
+    --animate-marquee: marquee 20s linear infinite;
 }

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -59,7 +59,7 @@
 /* h6-r */
 @utility text-h6-r {
   @apply typo-base;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   font-weight: 400;
 }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -18,7 +18,7 @@
 /* 스크롤바 */
   ::-webkit-scrollbar {
     width: 0.5rem;
-    /* height: 0.5rem; */
+    height: 0.5rem;
   }
   ::-webkit-scrollbar-track {
     background: transparent;

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -3,7 +3,7 @@
   --breakpoint-desktop: 1366px;    /* 1366 이하 */
   --breakpoint-laptop: 1024px;     /* 1024 이하 */
   --breakpoint-tablet: 720px;      /* 720 이하 */
-  --breakpoint-mobile: 460px;      /* 460 이하 (모바일) */
+  --breakpoint-mobile: 461px;      /* 460 이하 (모바일) */
 
   --breakpoint-sm-tablet: 550px; /* 로고-언어 붙는 구간 대응 */
 }


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) [feat/#2] - 폴더 순서 변경 기능 구현
    PR 날릴 때 Assignees는 자기 자신 선택 및 라벨 달기
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 1명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #15 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
컴포넌트
- `SuggestChip` 모바일 환경: 2줄로 마키 애니메이션 적용
- `SuggestChipGroup` 기존 `MainPage`에서 반복문으로 불러오던 SuggestChip들을 묶어 분리

훅
- `useVisualViewport` 구현
window.visualViewport API를 활용하여 실제 화면 높이를 정확히 계산. (100dvh가 키보드 높이를 반영하지 못하는 이슈 해결)
useSyncExternalStore를 사용해 외부 API 상태를 React 렌더링 사이클과 안전하게 동기화하고 무한 루프를 방지.
iOS 강제 스크롤 차단: `ChatInput` 포커스 시 브라우저가(특히 safari) 레이아웃을 밀어 올려 헤더가 사라지는 버그를 잡기 위해 window.scrollTo(0, 0) 고정 로직 추가.

기타
- Viewport 메타 태그 업데이트:
자동 확대(Auto-zoom) 방지 및 노치 영역 대응을 위해 viewport-fit=cover와 user-scalable=0 설정을 적용.
-> gemini 피드백으로 user-scalable 속성은 제거

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
<img width="322" height="682" alt="image" src="https://github.com/user-attachments/assets/25bc18a8-b749-4913-8774-872ff50adc8a" />


## 🌐 공유 사항 to 리뷰어

<!-- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 -->
<!-- 논의해야 할 부분이 있다면 적어주세요 -->
모바일(웹 개발자 모드 말고 실제 디바이스) 환경에서 간헐적으로 ChatInput 클릭시 화면 레이아웃이 깨지는 경우때문에 시간이 많이 소요되었습니다.
해결이 된 것 같으나 브라우저 특징때문에 같은 오류가 발생할 수 있어 계속 확인이 필요할 것 같습니다. 혹시 더 좋은 방법이 있다면 공유 부탁드립니다.

## 🚨 이슈 사항

<!-- 이슈가 발생하는 부분이 있다면 적어주세요 -->

