### PR TITLE
[feat/#22] - QueryBoundary 공통 에러/로딩 경계 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-error-boundary": "^6.1.1",
     "react-router-dom": "^7.13.1",
     "vaul": "^1.1.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.4(react@19.2.4)
+      react-error-boundary:
+        specifier: ^6.1.1
+        version: 6.1.1(react@19.2.4)
       react-router-dom:
         specifier: ^7.13.1
         version: 7.13.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1258,6 +1261,11 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-error-boundary@6.1.1:
+    resolution: {integrity: sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -2443,6 +2451,10 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-error-boundary@6.1.1(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   react-refresh@0.18.0: {}
 

--- a/src/components/boundary/ErrorFallback.tsx
+++ b/src/components/boundary/ErrorFallback.tsx
@@ -1,0 +1,22 @@
+import type { FallbackProps } from "react-error-boundary";
+
+
+const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-4 text-body">
+      <p className="text-h5-b">오류가 발생했습니다</p>
+      <p className="text-m-16 text-description">
+        {error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다"}
+      </p>
+      <button
+        type="button"
+        onClick={resetErrorBoundary}
+        className="px-4 py-2 rounded-lg bg-primary text-bg-white text-m-16 cursor-pointer"
+      >
+        다시 시도
+      </button>
+    </div>
+  );
+};
+
+export default ErrorFallback;

--- a/src/components/boundary/QueryBoundary.tsx
+++ b/src/components/boundary/QueryBoundary.tsx
@@ -1,0 +1,23 @@
+import { useQueryErrorResetBoundary } from "@tanstack/react-query";
+import { type ReactNode, Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import ErrorFallback from "./ErrorFallback";
+
+interface QueryBoundaryProps {
+  children: ReactNode;
+  loadingFallback?: ReactNode;
+}
+
+const QueryBoundary = ({ children, loadingFallback }: QueryBoundaryProps) => {
+  const { reset } = useQueryErrorResetBoundary();
+
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback} onReset={reset}>
+      <Suspense fallback={loadingFallback ?? <div className="flex items-center justify-center h-full text-description">로딩 중...</div>}>
+        {children}
+      </Suspense>
+    </ErrorBoundary>
+  );
+};
+
+export default QueryBoundary;


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) [feat/#2] - 폴더 순서 변경 기능 구현
    PR 날릴 때 Assignees는 자기 자신 선택 및 라벨 달기
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 1명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #22 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- Suspense + ErrorBoundary + useQueryErrorResetBoundary 조합의 공통 Boundary 컴포넌트 추가
- useSuspenseQuery 전환 시 별도 작업 없이 바로 사용 가능

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>
로딩스피너나 에러처리에 대한 디자인 추가 시 수정해야할 것 같습니다. 사용방법은 노션에 첨부해 두었습니다.