### PR TITLE
[fix/#37] - 채팅 페이지 관련 QA 반영

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",
     "react-spinners": "^0.17.0",
+    "remark-gfm": "^4.0.1",
     "vaul": "^1.1.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-spinners:
         specifier: ^0.17.0
         version: 0.17.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1094,6 +1097,10 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
@@ -1312,12 +1319,36 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -1342,6 +1373,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -1541,11 +1593,17 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2589,6 +2647,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@2.0.2: {}
@@ -2777,7 +2837,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -2793,6 +2862,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2885,6 +3011,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -3139,6 +3323,17 @@ snapshots:
 
   react@19.2.4: {}
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -3155,6 +3350,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   resolve-from@4.0.0: {}
 

--- a/src/components/input/MobileChatInput.tsx
+++ b/src/components/input/MobileChatInput.tsx
@@ -50,7 +50,7 @@ export const MobileChatInput = ({
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             placeholder="무엇이든 물어보세요"
-            className="w-full max-h-20 text-mb-r text-chat-text placeholder:text-description bg-transparent border-none outline-none resize-none overflow-hidden flex-1 p-0 m-0"
+            className="w-full max-h-20 text-mb-r leading-[1.4] text-chat-text placeholder:text-description bg-transparent border-none outline-none resize-none overflow-hidden flex-1 p-0 m-0 appearance-none"
           />
 
           <button

--- a/src/constants/breakpoints.ts
+++ b/src/constants/breakpoints.ts
@@ -1,2 +1,2 @@
 /** theme.css의 --breakpoint-mobile과 동일한 값을 유지해야 합니다. */
-export const MOBILE_BREAKPOINT = 461;
+export const MOBILE_BREAKPOINT = 481;

--- a/src/pages/chatPage/ChatPage.tsx
+++ b/src/pages/chatPage/ChatPage.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { ChatInput } from "@/components/input/ChatInput";
 import AIResponseSection from "./components/AIResponseSection";
 import ScrollToBottomButton from "./components/ScrollToBottomButton";
@@ -11,15 +10,14 @@ const ChatPage = () => {
   const {
     scrollContainerRef,
     contentRef,
-    bottomRef,
+    lastUserRef,
+    lastAIRef,
     showScrollBtn,
     scrollToBottom,
-  } = useScrollToBottom();
+  } = useScrollToBottom({ messages, isSubmitting });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on new message or response complete
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages.length, isSubmitting]);
+  const lastUserIndex = messages.findLastIndex((msg) => !("tailQuestions" in msg));
+  const lastAIIndex = messages.findLastIndex((msg) => "tailQuestions" in msg);
 
   return (
     <div className="flex flex-col h-full">
@@ -29,22 +27,24 @@ const ChatPage = () => {
           ref={contentRef}
           className="flex flex-col gap-10 chat-pl chat-pr pt-10"
         >
-          {messages.map((msg) =>
+          {messages.map((msg, idx) =>
             "tailQuestions" in msg ? (
-              <AIResponseSection
-                key={msg.id}
-                content={msg.content}
-                isLoading={msg.isLoading}
-                tailQuestions={msg.tailQuestions}
-                tailLoading={msg.tailLoading}
-                error={msg.error}
-                onTailQuestionClick={handleSubmit}
-              />
+              <div key={msg.id} ref={idx === lastAIIndex ? lastAIRef : undefined}>
+                <AIResponseSection
+                  content={msg.content}
+                  isLoading={msg.isLoading}
+                  tailQuestions={msg.tailQuestions}
+                  tailLoading={msg.tailLoading}
+                  error={msg.error}
+                  onTailQuestionClick={handleSubmit}
+                />
+              </div>
             ) : (
-              <UserMessage key={msg.id} content={msg.content} />
+              <div key={msg.id} ref={idx === lastUserIndex ? lastUserRef : undefined}>
+                <UserMessage content={msg.content} />
+              </div>
             )
           )}
-          <div ref={bottomRef} />
         </div>
       </div>
 

--- a/src/pages/chatPage/components/AIResponseSection.tsx
+++ b/src/pages/chatPage/components/AIResponseSection.tsx
@@ -43,7 +43,7 @@ const AIResponseSection = ({
           )}
         </div>
         {!error && tailQuestions.length > 0 && (
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 pb-4">
             {tailQuestions.map((q) => (
               <TailQuestion
                 key={q.id}

--- a/src/pages/chatPage/components/MarkdownContent.tsx
+++ b/src/pages/chatPage/components/MarkdownContent.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 const PROSE_STYLE: React.CSSProperties = {
   "--tw-prose-body": "var(--color-header-blue)",
@@ -19,7 +20,7 @@ interface MarkdownContentProps {
 const MarkdownContent = ({ children, className }: MarkdownContentProps) => {
   return (
     <div className={`prose max-w-none ${className ?? ""}`} style={PROSE_STYLE}>
-      <Markdown>{children}</Markdown>
+      <Markdown remarkPlugins={[remarkGfm]}>{children}</Markdown>
     </div>
   );
 };

--- a/src/pages/chatPage/hooks/useChatMessages.ts
+++ b/src/pages/chatPage/hooks/useChatMessages.ts
@@ -30,7 +30,7 @@ export const useChatMessages = () => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: roomDetail 변경 시에만 실행
   useEffect(() => {
     if (!roomDetail) return;
-    setMessages(toUIMessages(roomDetail.messages, nextId));
+    setMessages(toUIMessages(roomDetail, nextId));
   }, [roomDetail]);
 
   const handleSubmit = async (text: string) => {

--- a/src/pages/chatPage/hooks/useScrollToBottom.ts
+++ b/src/pages/chatPage/hooks/useScrollToBottom.ts
@@ -47,20 +47,29 @@ export const useScrollToBottom = ({
     };
   }, []);
 
-  // 유저 메시지 전송 시 → 유저 메시지 시작 지점으로
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll to user message on submit
-  useEffect(() => {
-    if (isSubmitting) {
-      lastUserRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
-  }, [messages.length]);
+  const prevIsSubmitting = useRef(isSubmitting);
+  const isInitialRender = useRef(true);
 
-  // AI 응답 완료 시 → AI 답변 시작 지점으로
   useEffect(() => {
-    if (!isSubmitting) {
+    // 최초 진입 시
+    if (isInitialRender.current && messages.length > 0) {
+      lastAIRef.current?.scrollIntoView({ behavior: "auto", block: "start" });
+      isInitialRender.current = false;
+    }
+    // 유저 메시지 전송 시 → 유저 메시지 시작 지점으로
+    else if (!prevIsSubmitting.current && isSubmitting) {
+      lastUserRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+    // AI 응답 완료 시 → AI 답변 시작 지점으로
+    else if (prevIsSubmitting.current && !isSubmitting) {
       lastAIRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
     }
-  }, [isSubmitting]);
+    // 상태 동기화
+    prevIsSubmitting.current = isSubmitting;
+  }, [isSubmitting, messages.length]);
 
   const scrollToBottom = () => {
     const container = scrollContainerRef.current;

--- a/src/pages/chatPage/hooks/useScrollToBottom.ts
+++ b/src/pages/chatPage/hooks/useScrollToBottom.ts
@@ -1,11 +1,21 @@
 import { useEffect, useRef, useState } from "react";
+import type { ChatMessage } from "@/types/chat.type";
 
 const BOTTOM_THRESHOLD = 10;
 
-export const useScrollToBottom = () => {
+interface UseScrollToBottomProps {
+  messages: ChatMessage[];
+  isSubmitting: boolean;
+}
+
+export const useScrollToBottom = ({
+  messages,
+  isSubmitting,
+}: UseScrollToBottomProps) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const lastUserRef = useRef<HTMLDivElement>(null);
+  const lastAIRef = useRef<HTMLDivElement>(null);
   const [showScrollBtn, setShowScrollBtn] = useState(false);
 
   const checkShouldShow = () => {
@@ -37,14 +47,32 @@ export const useScrollToBottom = () => {
     };
   }, []);
 
+  // 유저 메시지 전송 시 → 유저 메시지 시작 지점으로
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll to user message on submit
+  useEffect(() => {
+    if (isSubmitting) {
+      lastUserRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [messages.length]);
+
+  // AI 응답 완료 시 → AI 답변 시작 지점으로
+  useEffect(() => {
+    if (!isSubmitting) {
+      lastAIRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [isSubmitting]);
+
   const scrollToBottom = () => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
   };
 
   return {
     scrollContainerRef,
     contentRef,
-    bottomRef,
+    lastUserRef,
+    lastAIRef,
     showScrollBtn,
     scrollToBottom,
   };

--- a/src/pages/chatPage/utils/toUIMessages.ts
+++ b/src/pages/chatPage/utils/toUIMessages.ts
@@ -1,24 +1,31 @@
 import type {
   AIMessage,
   ChatMessage,
-  ChatRoomMessageEntity,
+  GetChatRoomDetailResponse,
 } from "@/types/chat.type";
 
 export const toUIMessages = (
-  messages: ChatRoomMessageEntity[],
+  roomDetail: GetChatRoomDetailResponse,
   nextId: () => number
-): ChatMessage[] =>
-  messages.map((msg) =>
+): ChatMessage[] => {
+  const { messages, suggestedQuestions } = roomDetail;
+  const lastAIIndex = messages.findLastIndex((m) => m.senderType === "AI");
+
+  return messages.map((msg, idx) =>
     msg.senderType === "USER"
       ? { id: nextId(), content: msg.content }
       : ({
           id: nextId(),
           content: msg.content,
           isLoading: false,
-          tailQuestions: (msg.suggestedQuestions ?? []).map((q) => ({
-            id: q.id,
-            text: q.question,
-          })),
+          tailQuestions:
+            idx === lastAIIndex && suggestedQuestions?.length
+              ? suggestedQuestions.map((q, i) => ({ id: i, text: q }))
+              : (msg.suggestedQuestions ?? []).map((q) => ({
+                  id: q.id,
+                  text: q.question,
+                })),
           tailLoading: false,
         } satisfies AIMessage)
   );
+};

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -3,7 +3,7 @@
   --breakpoint-desktop: 1366px;    /* 1366 이하 */
   --breakpoint-laptop: 1024px;     /* 1024 이하 */
   --breakpoint-tablet: 720px;      /* 720 이하 */
-  --breakpoint-mobile: 461px;      /* 460 이하 (모바일) */
+  --breakpoint-mobile: 481px;      /* 480 이하 (모바일) */
 
   --breakpoint-sm-tablet: 550px; /* 로고-언어 붙는 구간 대응 */
 }
@@ -30,13 +30,13 @@
 
 @utility chat-pl {
   padding-left: max(2.5rem, calc(50% - 29.34rem));
-  @media (max-width: 460px) {
+  @media (max-width: 480px) {
     padding-left: max(1rem, calc(50% - 29.34rem));
   }
 }
 @utility chat-pr {
   padding-right: max(2.5rem, calc(50% - 29.34rem));
-  @media (max-width: 460px) {
+  @media (max-width: 480px) {
     padding-right: max(1rem, calc(50% - 29.34rem));
   }
 }

--- a/src/types/chat.type.ts
+++ b/src/types/chat.type.ts
@@ -58,6 +58,7 @@ export type GetChatRoomDetailResponse = {
   title: string;
   createdAt: string;
   messages: ChatRoomMessageEntity[];
+  suggestedQuestions?: string[];
 };
 
 // 4. 프론트엔드 UI 상태 타입

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "types": ["vite/client", "vite-plugin-svgr/client"],
     "skipLibCheck": true,


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) [feat/#2] - 폴더 순서 변경 기능 구현
    PR 날릴 때 Assignees는 자기 자신 선택 및 라벨 달기
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 1명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #37 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
- 채팅 스크롤 동작 개선
  - 기존의 무조건적인 최하단 스크롤 방식을 메시지 시작점 기준으로 최적화
  - 유저 메시지 전송 시 해당 메시지 시작점, AI 응답 완료 시 답변 시작점으로 스크롤
  - lastUserRef, lastAIRef를 활용해 useScrollToBottom 훅으로 로직 통합 및 불필요한 DOM 엘리먼트 제거

- 마크다운 GFM 테이블 렌더링 지원
  - remark-gfm 라이브러리 추가로 AI 응답 내 표 형식 렌더링 가능

- Android WebView textarea placeholder 수직 정렬 이슈 수정
  - line-height: normal이 Android WebView에서 1.7 이상으로 계산되어 placeholder가 아래로 밀리는 현상 대응
  - leading-[1.4] 명시 및 appearance-none으로 UA 기본 스타일 리셋

- 모바일 브레이크포인트 조정 (461px → 481px)
  - breakpoints.ts, theme.css 파일에 동일하게 반영

- 서버 응답 구조 변경에 따른 꼬리질문 미표시 이슈 수정
  - suggestedQuestions 위치 변경(각 메시지 내부 → 응답 루트 레벨)에 따른 스펙 대응
  - GetChatRoomDetailResponse 타입 업데이트 및 toUIMessages 리팩토링

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->

## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>
- tsconfig.app.json lib을 ES2022 → ES2023으로 변경 (findLastIndex 사용을 위해). Vite(esbuild)가 트랜스파일을 담당하므로 빌드 출력 및 브라우저 호환성에는 영향 없음
- 카카오톡 인앱 WebView 포함 Android WebView 환경 기준으로 검증 필요
- \" 로 끝나는 AI 응답 (예: "죄송합니다. \"") 은 프론트 렌더링 문제가 아닌 AI 모델 생성 이슈로, 백엔드 response 후처리 논의 필요

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>
